### PR TITLE
added some more methods and made it so we can use elements instead of…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 [*]
-ens_of_line = lf
+end_of_line = lf
 insert_final_newline = true
 
 [*.js]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+ens_of_line = lf
+insert_final_newline = true
+
+[*.js]
+indent_style = space
+indent_size = 4
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.idea


### PR DESCRIPTION
… model strings as element identifiers

Backward incompat change: 
replace `selectOptionInMdSelectByText` with `selectOptionInMdSelectByModelByText`
