### PR TITLE
Fix for button clicking.

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ exports.selectOptionInMdSelectByText = function(selectElm, text) {
 };
 
 exports.clickMDContextMenuItem = function (openContextMenu, text) {
-    const menuItem = element(by.cssContainingText('.md-open-menu-container.md-active.md-clickable a', text));
+    const menuItem = element(by.cssContainingText('.md-open-menu-container.md-active.md-clickable .md-button', text));
     waitForElementToBeClickable(openContextMenu);
     openContextMenu.click();
     waitForElementToBeClickable(menuItem);


### PR DESCRIPTION
Instead of using an `a` element for the button, use `.md-button` instead. This is because the element is not guaranteed to be an `a`, it could also be a `button`. Using `.md-button` means everything will be matched.

Example:
```
<md-menu-content>
  <md-menu-item>
    <!-- Will create a 'button' element. -->
    <md-button ng-click="someFunc()">Foo</md-button>
  </md-menu-item>
  <md-menu-item>
    <!-- Will create an 'a' element. -->
    <md-button ng-href="/bar">Bar</md-button>
  </md-menu-item>
</md-menu-content>
```